### PR TITLE
feat: add MiniMax provider support for training data generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A 20 Questions game where the model knows a secret topic and answers YES/NO/MAYB
 
 ![GUESS.COM example](examples/guess/example.png)
 
-Includes tools for generating training data with LLMs (Ollama or Claude API) and balancing class distributions.
+Includes tools for generating training data with LLMs (Ollama, Claude API, or MiniMax API) and balancing class distributions.
 
 ## Quickstart
 

--- a/examples/guess/README.md
+++ b/examples/guess/README.md
@@ -49,6 +49,9 @@ Generates Q&A pairs using an LLM.
 # Claude API (faster, better quality)
 ./gendata.py --topic elephant --claude -n 500
 
+# MiniMax API (set MINIMAX_API_KEY env var)
+./gendata.py --topic elephant --minimax -n 500
+
 # With paraphrases (5 variations per question)
 ./gendata.py --topic elephant --claude -p 5 -n 500
 ```
@@ -59,6 +62,7 @@ Options:
 - `-d, --distractors` - Add wrong-topic questions (answered NO)
 - `--nonsense` - Add off-topic phrases (answered IDK)
 - `--claude` - Use Claude API instead of Ollama
+- `--minimax` - Use MiniMax API instead of Ollama
 - `--yes-only` - Only generate YES-answer questions
 - `--win-only` - Generate winning guesses
 - `-p, --paraphrase` - Generate N paraphrases per question

--- a/examples/guess/gendata.py
+++ b/examples/guess/gendata.py
@@ -14,6 +14,10 @@ Usage:
     ./gendata.py --topic elephant --claude -n 500 > training.txt
     ./gendata.py --topic elephant --claude --model claude-opus-4-20250514
 
+    # MiniMax API (set MINIMAX_API_KEY env var)
+    ./gendata.py --topic elephant --minimax -n 500 > training.txt
+    ./gendata.py --topic elephant --minimax --model MiniMax-M2.7-highspeed
+
     # With distractors and nonsense
     ./gendata.py --topic elephant -d 20 --nonsense --claude
 
@@ -23,7 +27,9 @@ Usage:
 
 import argparse
 import json
+import os
 import random
+import re
 import sys
 import urllib.request
 
@@ -36,6 +42,7 @@ except ImportError:
 
 DEFAULT_MODEL = 'gemma2:9b'
 DEFAULT_CLAUDE_MODEL = 'claude-sonnet-4-20250514'
+DEFAULT_MINIMAX_MODEL = 'MiniMax-M2.7'
 
 # Token tracking for cost estimation
 total_input_tokens = 0
@@ -304,6 +311,74 @@ def claude_json(model: str, prompt: str, max_tokens: int = 200) -> dict | None:
     return None
 
 
+def minimax_json(model: str, prompt: str, max_tokens: int = 200, temperature: float = 1.0) -> dict | None:
+    """Call MiniMax API (OpenAI-compatible) and return parsed JSON response."""
+    global total_input_tokens, total_output_tokens
+
+    api_key = os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        print("# Error: MINIMAX_API_KEY environment variable not set", file=sys.stderr)
+        return None
+
+    base_url = os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
+
+    # MiniMax temperature must be in (0.0, 1.0], clamp if needed
+    if temperature <= 0:
+        temperature = 0.01
+    elif temperature > 1.0:
+        temperature = 1.0
+
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt + "\nRespond with JSON only, no other text."}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+
+    try:
+        data = json.dumps(payload).encode('utf-8')
+        req = urllib.request.Request(
+            f"{base_url.rstrip('/')}/chat/completions",
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            }
+        )
+        with urllib.request.urlopen(req) as resp:
+            result = json.loads(resp.read().decode('utf-8'))
+
+            # Track tokens
+            usage = result.get("usage", {})
+            total_input_tokens += usage.get("prompt_tokens", 0)
+            total_output_tokens += usage.get("completion_tokens", 0)
+
+            # Get response text
+            response_text = ""
+            choices = result.get("choices", [])
+            if choices:
+                response_text = choices[0].get("message", {}).get("content", "").strip()
+
+            # Strip <think>...</think> tags (MiniMax chain-of-thought)
+            response_text = re.sub(r'<think>[\s\S]*?</think>', '', response_text).strip()
+
+            # Strip markdown code blocks if present
+            if response_text.startswith("```"):
+                lines = response_text.split("\n")
+                lines = [l for l in lines if not l.startswith("```")]
+                response_text = "\n".join(lines).strip()
+
+            try:
+                return json.loads(response_text)
+            except json.JSONDecodeError as e:
+                print(f"# JSON parse error: {e}", file=sys.stderr)
+                print(f"# Raw response: {response_text[:200]}", file=sys.stderr)
+    except Exception as e:
+        print(f"# MiniMax error: {e}", file=sys.stderr)
+
+    return None
+
+
 # Active backend function (set in main)
 api_json = ollama_json
 
@@ -529,8 +604,9 @@ def main():
     parser = argparse.ArgumentParser(description='Generate 20 questions training data')
     parser.add_argument('--topic', '-t', required=True, help='The secret topic/thing')
     parser.add_argument('-n', '--count', type=int, default=100, help='Number of Q&A pairs to generate')
-    parser.add_argument('--model', '-m', default=None, help='Model to use (default: gemma2:9b for ollama, claude-sonnet-4 for claude)')
+    parser.add_argument('--model', '-m', default=None, help='Model to use (default: gemma2:9b for ollama, claude-sonnet-4 for claude, MiniMax-M2.7 for minimax)')
     parser.add_argument('--claude', action='store_true', help='Use Claude API instead of Ollama')
+    parser.add_argument('--minimax', action='store_true', help='Use MiniMax API instead of Ollama (set MINIMAX_API_KEY env var)')
     parser.add_argument('--batch', '-b', type=int, default=10, help='Questions per LLM call')
     parser.add_argument('--distractors', '-d', type=int, default=10, help='Number of wrong guesses to auto-generate (0 to disable)')
     parser.add_argument('--nonsense', action='store_true', help='Add nonsense/gibberish -> IDK training')
@@ -547,13 +623,21 @@ def main():
         api_json = lambda model, prompt, max_tokens=200: claude_json(model, prompt, max_tokens)
         if args.model is None:
             args.model = DEFAULT_CLAUDE_MODEL
+    elif args.minimax:
+        if not os.environ.get("MINIMAX_API_KEY"):
+            print("# Error: MINIMAX_API_KEY environment variable not set", file=sys.stderr)
+            sys.exit(1)
+        # MiniMax uses chain-of-thought internally, so scale up max_tokens
+        api_json = lambda model, prompt, max_tokens=200: minimax_json(model, prompt, max(max_tokens * 4, 2048))
+        if args.model is None:
+            args.model = DEFAULT_MINIMAX_MODEL
     else:
         api_json = lambda model, prompt, max_tokens=200, temp=0.75: ollama_json(model, prompt, max_tokens, temp)
         if args.model is None:
             args.model = DEFAULT_MODEL
 
     topic = args.topic.lower()
-    backend = "claude" if args.claude else "ollama"
+    backend = "claude" if args.claude else ("minimax" if args.minimax else "ollama")
     print(f"# Topic: {topic}", file=sys.stderr)
     print(f"# Backend: {backend} | Model: {args.model}", file=sys.stderr)
     print(f"# Generating {args.count} Q&A pairs...", file=sys.stderr)

--- a/examples/guess/test_gendata.py
+++ b/examples/guess/test_gendata.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Unit tests for gendata.py MiniMax integration."""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+from io import BytesIO
+
+# Add the directory to path so we can import gendata
+sys.path.insert(0, os.path.dirname(__file__))
+import gendata
+
+
+class TestMiniMaxDefaults(unittest.TestCase):
+    """Test MiniMax default configuration values."""
+
+    def test_default_model_defined(self):
+        self.assertEqual(gendata.DEFAULT_MINIMAX_MODEL, 'MiniMax-M2.7')
+
+    def test_default_claude_model_unchanged(self):
+        self.assertEqual(gendata.DEFAULT_CLAUDE_MODEL, 'claude-sonnet-4-20250514')
+
+    def test_default_ollama_model_unchanged(self):
+        self.assertEqual(gendata.DEFAULT_MODEL, 'gemma2:9b')
+
+
+class TestMiniMaxJson(unittest.TestCase):
+    """Test minimax_json function."""
+
+    def setUp(self):
+        gendata.total_input_tokens = 0
+        gendata.total_output_tokens = 0
+
+    def test_returns_none_without_api_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove MINIMAX_API_KEY if it exists
+            os.environ.pop('MINIMAX_API_KEY', None)
+            result = gendata.minimax_json('MiniMax-M2.7', 'test prompt')
+            self.assertIsNone(result)
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_successful_json_response(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"pairs": [{"q": "is it big", "a": "YES"}]}'}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            result = gendata.minimax_json('MiniMax-M2.7', 'test prompt')
+
+        self.assertIsNotNone(result)
+        self.assertIn('pairs', result)
+        self.assertEqual(gendata.total_input_tokens, 10)
+        self.assertEqual(gendata.total_output_tokens, 20)
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_correct_request_url(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        # Verify the URL used
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]
+        self.assertEqual(request_obj.full_url, 'https://api.minimax.io/v1/chat/completions')
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_custom_base_url(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {
+            'MINIMAX_API_KEY': 'test-key',
+            'MINIMAX_BASE_URL': 'https://api.minimaxi.com/v1'
+        }):
+            gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]
+        self.assertEqual(request_obj.full_url, 'https://api.minimaxi.com/v1/chat/completions')
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_authorization_header(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'my-secret-key'}):
+            gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]
+        self.assertEqual(request_obj.get_header('Authorization'), 'Bearer my-secret-key')
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_request_body_structure(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            gendata.minimax_json('MiniMax-M2.7', 'test prompt', max_tokens=100)
+
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]
+        body = json.loads(request_obj.data.decode('utf-8'))
+
+        self.assertEqual(body['model'], 'MiniMax-M2.7')
+        self.assertEqual(body['max_tokens'], 100)
+        self.assertIn('messages', body)
+        self.assertEqual(len(body['messages']), 1)
+        self.assertEqual(body['messages'][0]['role'], 'user')
+        self.assertIn('JSON only', body['messages'][0]['content'])
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_temperature_default_is_one(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]
+        body = json.loads(request_obj.data.decode('utf-8'))
+        self.assertEqual(body['temperature'], 1.0)
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_temperature_zero_clamped(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            gendata.minimax_json('MiniMax-M2.7', 'test', temperature=0)
+
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]
+        body = json.loads(request_obj.data.decode('utf-8'))
+        self.assertGreater(body['temperature'], 0)
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_temperature_above_one_clamped(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            gendata.minimax_json('MiniMax-M2.7', 'test', temperature=2.0)
+
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]
+        body = json.loads(request_obj.data.decode('utf-8'))
+        self.assertLessEqual(body['temperature'], 1.0)
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_strips_markdown_code_blocks(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '```json\n{"result": "ok"}\n```'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            result = gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result['result'], 'ok')
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_strips_think_tags(self, mock_urlopen):
+        """MiniMax may return <think>...</think> chain-of-thought tags."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '<think>\nLet me think about this...\n</think>\n{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            result = gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result['result'], 'ok')
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_handles_api_error(self, mock_urlopen):
+        mock_urlopen.side_effect = Exception("Connection refused")
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            result = gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        self.assertIsNone(result)
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_handles_invalid_json_response(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": "not valid json"}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            result = gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        self.assertIsNone(result)
+
+    @patch('gendata.urllib.request.urlopen')
+    def test_no_response_format_in_request(self, mock_urlopen):
+        """Verify response_format is not sent (MiniMax doesn't support it)."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "choices": [{"message": {"content": '{"result": "ok"}'}}],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0}
+        }).encode('utf-8')
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        with patch.dict(os.environ, {'MINIMAX_API_KEY': 'test-key'}):
+            gendata.minimax_json('MiniMax-M2.7', 'test')
+
+        call_args = mock_urlopen.call_args
+        request_obj = call_args[0][0]
+        body = json.loads(request_obj.data.decode('utf-8'))
+        self.assertNotIn('response_format', body)
+
+
+class TestMiniMaxCLI(unittest.TestCase):
+    """Test CLI argument parsing for --minimax flag."""
+
+    def test_minimax_flag_exits_without_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop('MINIMAX_API_KEY', None)
+            with patch('sys.argv', ['gendata.py', '--topic', 'test', '--minimax']):
+                with self.assertRaises(SystemExit):
+                    gendata.main()
+
+    def test_claude_and_minimax_flags_exist(self):
+        """Verify both --claude and --minimax flags are available."""
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--claude', action='store_true')
+        parser.add_argument('--minimax', action='store_true')
+        args = parser.parse_args(['--minimax'])
+        self.assertTrue(args.minimax)
+        self.assertFalse(args.claude)
+
+
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration test with real MiniMax API (skipped if no API key)."""
+
+    @unittest.skipUnless(os.environ.get('MINIMAX_API_KEY'), 'MINIMAX_API_KEY not set')
+    def test_real_api_call(self):
+        """Test actual MiniMax API call with a simple prompt."""
+        gendata.total_input_tokens = 0
+        gendata.total_output_tokens = 0
+
+        result = gendata.minimax_json(
+            'MiniMax-M2.7',
+            'Generate 2 yes/no questions about elephants. Return JSON: {"pairs": [{"q": "question", "a": "YES"}]}',
+            max_tokens=1024
+        )
+
+        self.assertIsNotNone(result, "MiniMax API returned None - check API key and connectivity")
+        self.assertIn('pairs', result)
+        self.assertGreater(len(result['pairs']), 0)
+        self.assertGreater(gendata.total_input_tokens, 0)
+        self.assertGreater(gendata.total_output_tokens, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as a third LLM backend option for generating training data in `gendata.py`, alongside Ollama and Claude API.

### Changes

- **New `--minimax` flag** for `gendata.py` to use MiniMax API (OpenAI-compatible endpoint)
- **Supported models**: `MiniMax-M2.7` (default) and `MiniMax-M2.7-highspeed`
- **No new dependencies** — uses `urllib.request` (same pattern as Ollama integration)
- **Chain-of-thought handling** — strips `<think>` tags from MiniMax responses
- **Temperature clamping** — enforces MiniMax's valid range `(0.0, 1.0]`
- **Environment variables**: `MINIMAX_API_KEY` (required), `MINIMAX_BASE_URL` (optional)
- **Unit tests**: 20 tests including real API integration test
- **Documentation**: Updated README.md and examples/guess/README.md

### Usage

```bash
# Set API key
export MINIMAX_API_KEY="your-key"

# Generate training data with MiniMax
./gendata.py --topic elephant --minimax -n 500 > training.txt

# Use highspeed model
./gendata.py --topic elephant --minimax --model MiniMax-M2.7-highspeed -n 500
```

### API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test Plan

- [x] All 20 unit tests pass (provider config, URL construction, auth headers, temperature clamping, think-tag stripping, error handling)
- [x] Integration test passes with real MiniMax API
- [x] End-to-end CLI test generates valid training data (`--minimax` flag)
- [x] Existing Ollama and Claude backends remain unaffected
- [x] `python3 -c "import ast; ast.parse(open('examples/guess/gendata.py').read())"` passes